### PR TITLE
chore: update runpod to 1.7.12

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-runpod~=1.7.9
+runpod~=1.7.12
 websocket-client
 requests


### PR DESCRIPTION
## Motivation

* update runpod to 1.7.12 to have the latest bug fixes related to the queue
