### PR TITLE
fix: update runpod to 1.7.12 to fix problems with the queue

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+# fix some problems with the queue
 runpod~=1.7.12
 websocket-client
 requests


### PR DESCRIPTION
## Motivation

* update runpod to 1.7.12 to fix problems with the queue
