### PR TITLE
Add extra model paths for WAN

### DIFF
--- a/src/extra_model_paths.yaml
+++ b/src/extra_model_paths.yaml
@@ -10,3 +10,6 @@ runpod_worker_comfy:
   upscale_models: models/upscale_models/
   vae: models/vae/
   unet: models/unet/
+  diffusion_models: models/diffusion_models/
+  audio_encoders: models/audio_encoders/
+  text_encoders: models/text_encoders/

--- a/src/extra_model_paths.yaml
+++ b/src/extra_model_paths.yaml
@@ -13,3 +13,4 @@ runpod_worker_comfy:
   diffusion_models: models/diffusion_models/
   audio_encoders: models/audio_encoders/
   text_encoders: models/text_encoders/
+  loras: models/loras/


### PR DESCRIPTION
## Motivation
Add additional extra model paths for WAN models to discover diffusion_models, audio_encoders, text_encoders.
<!-- List motivation and changes here -->

## Issues closed
https://github.com/runpod-workers/worker-comfyui/issues/165
<!-- List closed issues here -->
