### PR TITLE
feat!: switch default hub model to FLUX.2 klein 9B (Q5_K_M GGUF)

### DIFF
--- a/.changeset/flux2-klein-default.md
+++ b/.changeset/flux2-klein-default.md
@@ -1,0 +1,9 @@
+---
+"worker-comfyui": major
+---
+
+feat!: switch default hub model from FLUX.1-dev-fp8 to FLUX.2 klein 9B (Q5_K_M GGUF)
+
+BREAKING CHANGE: The default hub deployment now uses FLUX.2 klein 9B instead of FLUX.1-dev-fp8.
+Existing workflows using CheckpointLoaderSimple with flux1-dev-fp8.safetensors will not work
+with the new default image. Use the flux1-dev-fp8 image tag for backward compatibility.

--- a/.github/workflows/manual-build-all.yml
+++ b/.github/workflows/manual-build-all.yml
@@ -366,6 +366,57 @@ jobs:
             *.args.RELEASE_VERSION=${{ env.RELEASE_VERSION }}
             *.args.HUGGINGFACE_ACCESS_TOKEN=${{ env.HUGGINGFACE_ACCESS_TOKEN }}
 
+  build-flux2-klein-9b:
+    runs-on: [blacksmith-8vcpu-ubuntu-2204, linux]
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Clear space to remove unused folders
+        run: |
+          rm -rf /usr/share/dotnet
+          rm -rf /opt/ghc
+          rm -rf "/usr/local/share/boost"
+          rm -rf "$AGENT_TOOLSDIRECTORY"
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: blacksmith docker layer cache
+        uses: useblacksmith/build-push-action@v1
+        with:
+          setup-only: true
+
+      - name: Set environment variables
+        run: |
+          echo "DOCKERHUB_REPO=${{ vars.DOCKERHUB_REPO }}" >> $GITHUB_ENV
+          echo "DOCKERHUB_IMG=${{ vars.DOCKERHUB_IMG }}" >> $GITHUB_ENV
+          echo "HUGGINGFACE_ACCESS_TOKEN=${{ secrets.HUGGINGFACE_ACCESS_TOKEN }}" >> $GITHUB_ENV
+          echo "RELEASE_VERSION=${{ github.event.inputs.version }}" >> $GITHUB_ENV
+
+      - name: Build and push flux2-klein-9b image
+        uses: docker/bake-action@v2
+        with:
+          push: true
+          targets: flux2-klein-9b
+          set: |
+            *.args.DOCKERHUB_REPO=${{ env.DOCKERHUB_REPO }}
+            *.args.DOCKERHUB_IMG=${{ env.DOCKERHUB_IMG }}
+            *.args.RELEASE_VERSION=${{ env.RELEASE_VERSION }}
+            *.args.HUGGINGFACE_ACCESS_TOKEN=${{ env.HUGGINGFACE_ACCESS_TOKEN }}
+
   build-z-image-turbo:
     runs-on: [blacksmith-8vcpu-ubuntu-2204, linux]
     permissions:
@@ -428,6 +479,7 @@ jobs:
         build-flux1-schnell,
         build-flux1-dev,
         build-flux1-dev-fp8,
+        build-flux2-klein-9b,
         build-z-image-turbo,
       ]
     permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,6 +84,7 @@ jobs:
           - flux1-schnell
           - flux1-dev
           - flux1-dev-fp8
+          - flux2-klein-9b
           - z-image-turbo
           - base-cuda12-8-1
 

--- a/.runpod/README.md
+++ b/.runpod/README.md
@@ -12,11 +12,11 @@ Run [ComfyUI](https://github.com/comfyanonymous/ComfyUI) workflows as a serverle
 
 ## What is included?
 
-This worker comes with the **FLUX.1-dev-fp8** (`flux1-dev-fp8.safetensors`) model pre-installed and **works only with this specific model** when deployed from the hub.
+This worker comes with the **FLUX.2 klein 9B** (`flux-2-klein-9b-Q5_K_M.gguf`) model pre-installed and **works only with this specific model** when deployed from the hub.
 
 ## Want to use a different model?
 
-**The hub deployment only supports FLUX.1-dev-fp8.** If you need any other model, custom nodes, or LoRAs, you have two options:
+**The hub deployment only supports FLUX.2 klein 9B (Q5_K_M GGUF).** If you need any other model, custom nodes, or LoRAs, you have two options:
 
 ### Option 1: ComfyUI-to-API (Easiest & Recommended)
 
@@ -60,20 +60,87 @@ This example uses a simplified workflow (replace with your actual workflow JSON)
 {
   "input": {
     "workflow": {
-      "6": {
+      "1": {
+        "inputs": {
+          "unet_name": "flux-2-klein-9b-Q5_K_M.gguf"
+        },
+        "class_type": "UnetLoaderGGUF",
+        "_meta": {
+          "title": "Load GGUF Model"
+        }
+      },
+      "2": {
+        "inputs": {
+          "clip_name": "qwen_3_8b_fp8mixed.safetensors",
+          "type": "flux2"
+        },
+        "class_type": "CLIPLoader",
+        "_meta": {
+          "title": "Load Text Encoder"
+        }
+      },
+      "3": {
+        "inputs": {
+          "vae_name": "flux2-vae.safetensors"
+        },
+        "class_type": "VAELoader",
+        "_meta": {
+          "title": "Load VAE"
+        }
+      },
+      "4": {
         "inputs": {
           "text": "anime cat with massive fluffy fennec ears and a big fluffy tail blonde messy long hair blue eyes wearing a construction outfit placing a fancy black forest cake with candles on top of a dinner table of an old dark Victorian mansion lit by candlelight with a bright window to the foggy forest and very expensive stuff everywhere there are paintings on the walls",
-          "clip": ["30", 1]
+          "clip": ["2", 0]
         },
         "class_type": "CLIPTextEncode",
         "_meta": {
           "title": "CLIP Text Encode (Positive Prompt)"
         }
       },
+      "5": {
+        "inputs": {
+          "text": "",
+          "clip": ["2", 0]
+        },
+        "class_type": "CLIPTextEncode",
+        "_meta": {
+          "title": "CLIP Text Encode (Negative Prompt)"
+        }
+      },
+      "6": {
+        "inputs": {
+          "width": 1024,
+          "height": 1024,
+          "batch_size": 1
+        },
+        "class_type": "EmptyLatentImage",
+        "_meta": {
+          "title": "Empty Latent Image"
+        }
+      },
+      "7": {
+        "inputs": {
+          "seed": 243057879077961,
+          "steps": 4,
+          "cfg": 1,
+          "sampler_name": "euler",
+          "scheduler": "simple",
+          "denoise": 1,
+          "model": ["1", 0],
+          "positive": ["4", 0],
+          "negative": ["5", 0],
+          "latent_image": ["6", 0]
+        },
+        "class_type": "KSampler",
+        "_meta": {
+          "title": "KSampler"
+        }
+      },
       "8": {
         "inputs": {
-          "samples": ["31", 0],
-          "vae": ["30", 2]
+          "samples": ["7", 0],
+          "vae": ["3", 0]
         },
         "class_type": "VAEDecode",
         "_meta": {
@@ -81,83 +148,6 @@ This example uses a simplified workflow (replace with your actual workflow JSON)
         }
       },
       "9": {
-        "inputs": {
-          "filename_prefix": "ComfyUI",
-          "images": ["8", 0]
-        },
-        "class_type": "SaveImage",
-        "_meta": {
-          "title": "Save Image"
-        }
-      },
-      "27": {
-        "inputs": {
-          "width": 512,
-          "height": 512,
-          "batch_size": 1
-        },
-        "class_type": "EmptySD3LatentImage",
-        "_meta": {
-          "title": "EmptySD3LatentImage"
-        }
-      },
-      "30": {
-        "inputs": {
-          "ckpt_name": "flux1-dev-fp8.safetensors"
-        },
-        "class_type": "CheckpointLoaderSimple",
-        "_meta": {
-          "title": "Load Checkpoint"
-        }
-      },
-      "31": {
-        "inputs": {
-          "seed": 243057879077961,
-          "steps": 10,
-          "cfg": 1,
-          "sampler_name": "euler",
-          "scheduler": "simple",
-          "denoise": 1,
-          "model": ["30", 0],
-          "positive": ["35", 0],
-          "negative": ["33", 0],
-          "latent_image": ["27", 0]
-        },
-        "class_type": "KSampler",
-        "_meta": {
-          "title": "KSampler"
-        }
-      },
-      "33": {
-        "inputs": {
-          "text": "",
-          "clip": ["30", 1]
-        },
-        "class_type": "CLIPTextEncode",
-        "_meta": {
-          "title": "CLIP Text Encode (Negative Prompt)"
-        }
-      },
-      "35": {
-        "inputs": {
-          "guidance": 3.5,
-          "conditioning": ["6", 0]
-        },
-        "class_type": "FluxGuidance",
-        "_meta": {
-          "title": "FluxGuidance"
-        }
-      },
-      "38": {
-        "inputs": {
-          "images": ["8", 0]
-        },
-        "class_type": "PreviewImage",
-        "_meta": {
-          "title": "Preview Image"
-        }
-      },
-      "40": {
         "inputs": {
           "filename_prefix": "ComfyUI",
           "images": ["8", 0]

--- a/.runpod/hub.json
+++ b/.runpod/hub.json
@@ -1,12 +1,12 @@
 {
   "title": "ComfyUI",
-  "description": "Generate images with ComfyUI using FLUX.1-dev (fp8)",
+  "description": "Generate images with ComfyUI using FLUX.2 klein 9B (Q5_K_M GGUF)",
   "type": "serverless",
   "category": "image",
   "iconUrl": "https://cpjrphpz3t5wbwfe.public.blob.vercel-storage.com/comfy-ui.png",
   "config": {
     "runsOn": "GPU",
-    "containerDiskInGb": 20,
+    "containerDiskInGb": 25,
     "gpuIds": "ADA_24",
     "gpuCount": 1,
     "allowedCudaVersions": ["12.7", "12.6"],

--- a/.runpod/tests_.json
+++ b/.runpod/tests_.json
@@ -3,27 +3,88 @@
     {
       "name": "basic_test",
       "input": {
-        "images": [
-          {
-            "name": "test.png",
-            "image": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAIAAAD8GO2jAAAAMklEQVR4nGI5ZdXAQEvARFPTRy0YtWDUglELRi0YtWDUglELRi0YtWDUAioCQAAAAP//E24Bx3jUKuYAAAAASUVORK5CYII="
-          }
-        ],
         "workflow": {
-          "6": {
+          "1": {
+            "inputs": {
+              "unet_name": "flux-2-klein-9b-Q5_K_M.gguf"
+            },
+            "class_type": "UnetLoaderGGUF",
+            "_meta": {
+              "title": "Load GGUF Model"
+            }
+          },
+          "2": {
+            "inputs": {
+              "clip_name": "qwen_3_8b_fp8mixed.safetensors",
+              "type": "flux2"
+            },
+            "class_type": "CLIPLoader",
+            "_meta": {
+              "title": "Load Text Encoder"
+            }
+          },
+          "3": {
+            "inputs": {
+              "vae_name": "flux2-vae.safetensors"
+            },
+            "class_type": "VAELoader",
+            "_meta": {
+              "title": "Load VAE"
+            }
+          },
+          "4": {
             "inputs": {
               "text": "anime cat with massive fluffy fennec ears and a big fluffy tail blonde messy long hair blue eyes wearing a construction outfit placing a fancy black forest cake with candles on top of a dinner table of an old dark Victorian mansion lit by candlelight with a bright window to the foggy forest and very expensive stuff everywhere there are paintings on the walls",
-              "clip": ["30", 1]
+              "clip": ["2", 0]
             },
             "class_type": "CLIPTextEncode",
             "_meta": {
               "title": "CLIP Text Encode (Positive Prompt)"
             }
           },
+          "5": {
+            "inputs": {
+              "text": "",
+              "clip": ["2", 0]
+            },
+            "class_type": "CLIPTextEncode",
+            "_meta": {
+              "title": "CLIP Text Encode (Negative Prompt)"
+            }
+          },
+          "6": {
+            "inputs": {
+              "width": 1024,
+              "height": 1024,
+              "batch_size": 1
+            },
+            "class_type": "EmptyLatentImage",
+            "_meta": {
+              "title": "Empty Latent Image"
+            }
+          },
+          "7": {
+            "inputs": {
+              "seed": 243057879077961,
+              "steps": 4,
+              "cfg": 1,
+              "sampler_name": "euler",
+              "scheduler": "simple",
+              "denoise": 1,
+              "model": ["1", 0],
+              "positive": ["4", 0],
+              "negative": ["5", 0],
+              "latent_image": ["6", 0]
+            },
+            "class_type": "KSampler",
+            "_meta": {
+              "title": "KSampler"
+            }
+          },
           "8": {
             "inputs": {
-              "samples": ["31", 0],
-              "vae": ["30", 2]
+              "samples": ["7", 0],
+              "vae": ["3", 0]
             },
             "class_type": "VAEDecode",
             "_meta": {
@@ -31,83 +92,6 @@
             }
           },
           "9": {
-            "inputs": {
-              "filename_prefix": "ComfyUI",
-              "images": ["8", 0]
-            },
-            "class_type": "SaveImage",
-            "_meta": {
-              "title": "Save Image"
-            }
-          },
-          "27": {
-            "inputs": {
-              "width": 512,
-              "height": 512,
-              "batch_size": 1
-            },
-            "class_type": "EmptySD3LatentImage",
-            "_meta": {
-              "title": "EmptySD3LatentImage"
-            }
-          },
-          "30": {
-            "inputs": {
-              "ckpt_name": "flux1-dev-fp8.safetensors"
-            },
-            "class_type": "CheckpointLoaderSimple",
-            "_meta": {
-              "title": "Load Checkpoint"
-            }
-          },
-          "31": {
-            "inputs": {
-              "seed": 243057879077961,
-              "steps": 10,
-              "cfg": 1,
-              "sampler_name": "euler",
-              "scheduler": "simple",
-              "denoise": 1,
-              "model": ["30", 0],
-              "positive": ["35", 0],
-              "negative": ["33", 0],
-              "latent_image": ["27", 0]
-            },
-            "class_type": "KSampler",
-            "_meta": {
-              "title": "KSampler"
-            }
-          },
-          "33": {
-            "inputs": {
-              "text": "",
-              "clip": ["30", 1]
-            },
-            "class_type": "CLIPTextEncode",
-            "_meta": {
-              "title": "CLIP Text Encode (Negative Prompt)"
-            }
-          },
-          "35": {
-            "inputs": {
-              "guidance": 3.5,
-              "conditioning": ["6", 0]
-            },
-            "class_type": "FluxGuidance",
-            "_meta": {
-              "title": "FluxGuidance"
-            }
-          },
-          "38": {
-            "inputs": {
-              "images": ["8", 0]
-            },
-            "class_type": "PreviewImage",
-            "_meta": {
-              "title": "Preview Image"
-            }
-          },
-          "40": {
             "inputs": {
               "filename_prefix": "ComfyUI",
               "images": ["8", 0]

--- a/Dockerfile
+++ b/Dockerfile
@@ -85,6 +85,9 @@ RUN chmod +x /usr/local/bin/comfy-node-install
 # Prevent pip from asking for confirmation during uninstall steps in custom nodes
 ENV PIP_NO_INPUT=1
 
+# Install ComfyUI-GGUF for GGUF model format support
+RUN comfy-node-install comfyui-gguf
+
 # Copy helper script to switch Manager network mode at container start
 COPY scripts/comfy-manager-set-mode.sh /usr/local/bin/comfy-manager-set-mode
 RUN chmod +x /usr/local/bin/comfy-manager-set-mode
@@ -97,7 +100,7 @@ FROM base AS downloader
 
 ARG HUGGINGFACE_ACCESS_TOKEN
 # Set default model type if none is provided
-ARG MODEL_TYPE=flux1-dev-fp8
+ARG MODEL_TYPE=flux2-klein-9b
 
 # Change working directory to ComfyUI
 WORKDIR /comfyui
@@ -132,6 +135,12 @@ RUN if [ "$MODEL_TYPE" = "flux1-dev" ]; then \
 
 RUN if [ "$MODEL_TYPE" = "flux1-dev-fp8" ]; then \
       wget -q -O models/checkpoints/flux1-dev-fp8.safetensors https://huggingface.co/Comfy-Org/flux1-dev/resolve/main/flux1-dev-fp8.safetensors; \
+    fi
+
+RUN if [ "$MODEL_TYPE" = "flux2-klein-9b" ]; then \
+      wget -q -O models/unet/flux-2-klein-9b-Q5_K_M.gguf https://huggingface.co/unsloth/FLUX.2-klein-9B-GGUF/resolve/main/flux-2-klein-9b-Q5_K_M.gguf && \
+      wget -q --header="Authorization: Bearer ${HUGGINGFACE_ACCESS_TOKEN}" -O models/text_encoders/qwen_3_8b_fp8mixed.safetensors https://huggingface.co/Comfy-Org/flux2-klein-9B/resolve/main/split_files/text_encoders/qwen_3_8b_fp8mixed.safetensors && \
+      wget -q --header="Authorization: Bearer ${HUGGINGFACE_ACCESS_TOKEN}" -O models/vae/flux2-vae.safetensors https://huggingface.co/Comfy-Org/flux2-klein-9B/resolve/main/split_files/vae/flux2-vae.safetensors; \
     fi
 
 RUN if [ "$MODEL_TYPE" = "z-image-turbo" ]; then \

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ This project allows you to run ComfyUI workflows as a serverless API endpoint on
 These images are available on Docker Hub under `runpod/worker-comfyui`:
 
 - **`runpod/worker-comfyui:<version>-base`**: Clean ComfyUI install with no models.
+- **`runpod/worker-comfyui:<version>-flux2-klein-9b`**: Includes GGUF model, text encoder, and VAE for [FLUX.2 klein 9B](https://huggingface.co/unsloth/FLUX.2-klein-9B-GGUF) (Q5_K_M GGUF).
 - **`runpod/worker-comfyui:<version>-flux1-schnell`**: Includes checkpoint, text encoders, and VAE for [FLUX.1 schnell](https://huggingface.co/black-forest-labs/FLUX.1-schnell).
 - **`runpod/worker-comfyui:<version>-flux1-dev`**: Includes checkpoint, text encoders, and VAE for [FLUX.1 dev](https://huggingface.co/black-forest-labs/FLUX.1-dev).
 - **`runpod/worker-comfyui:<version>-sdxl`**: Includes checkpoint and VAEs for [Stable Diffusion XL](https://huggingface.co/stabilityai/stable-diffusion-xl-base-1.0).

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -36,7 +36,7 @@ variable "HUGGINGFACE_ACCESS_TOKEN" {
 }
 
 group "default" {
-  targets = ["base", "sdxl", "sd3", "flux1-schnell", "flux1-dev", "flux1-dev-fp8", "z-image-turbo", "base-cuda12-8-1"]
+  targets = ["base", "sdxl", "sd3", "flux1-schnell", "flux1-dev", "flux1-dev-fp8", "flux2-klein-9b", "z-image-turbo", "base-cuda12-8-1"]
 }
 
 target "base" {
@@ -135,6 +135,23 @@ target "flux1-dev-fp8" {
     MODEL_TYPE = "flux1-dev-fp8"
   }
   tags = ["${DOCKERHUB_REPO}/${DOCKERHUB_IMG}:${RELEASE_VERSION}-flux1-dev-fp8"]
+  inherits = ["base"]
+}
+
+target "flux2-klein-9b" {
+  context = "."
+  dockerfile = "Dockerfile"
+  target = "final"
+  args = {
+    BASE_IMAGE = "${BASE_IMAGE}"
+    COMFYUI_VERSION = "${COMFYUI_VERSION}"
+    CUDA_VERSION_FOR_COMFY = "${CUDA_VERSION_FOR_COMFY}"
+    ENABLE_PYTORCH_UPGRADE = "${ENABLE_PYTORCH_UPGRADE}"
+    PYTORCH_INDEX_URL = "${PYTORCH_INDEX_URL}"
+    MODEL_TYPE = "flux2-klein-9b"
+    HUGGINGFACE_ACCESS_TOKEN = "${HUGGINGFACE_ACCESS_TOKEN}"
+  }
+  tags = ["${DOCKERHUB_REPO}/${DOCKERHUB_IMG}:${RELEASE_VERSION}-flux2-klein-9b"]
   inherits = ["base"]
 }
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -41,6 +41,7 @@ This is the simplest method if the official images meet your needs.
 
 | Model                     | Image Tag Suffix | Minimum VRAM Required | Recommended Container Size |
 | ------------------------- | ---------------- | --------------------- | -------------------------- |
+| FLUX.2 klein 9B (GGUF)    | `flux2-klein-9b` | 16 GB                 | 25 GB                      |
 | Stable Diffusion XL       | `sdxl`           | 8 GB                  | 15 GB                      |
 | Stable Diffusion 3 Medium | `sd3`            | 5 GB                  | 20 GB                      |
 | FLUX.1 Schnell            | `flux1-schnell`  | 24 GB                 | 30 GB                      |

--- a/src/extra_model_paths.yaml
+++ b/src/extra_model_paths.yaml
@@ -10,3 +10,5 @@ runpod_worker_comfy:
   upscale_models: models/upscale_models/
   vae: models/vae/
   unet: models/unet/
+  diffusion_models: models/diffusion_models/
+  text_encoders: models/text_encoders/

--- a/test_input.json
+++ b/test_input.json
@@ -1,26 +1,87 @@
 {
   "input": {
-    "images": [
-      {
-        "name": "test.png",
-        "image": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAIAAAD8GO2jAAAAMklEQVR4nGI5ZdXAQEvARFPTRy0YtWDUglELRi0YtWDUglELRi0YtWDUAioCQAAAAP//E24Bx3jUKuYAAAAASUVORK5CYII="
-      }
-    ],
     "workflow": {
-      "6": {
+      "1": {
+        "inputs": {
+          "unet_name": "flux-2-klein-9b-Q5_K_M.gguf"
+        },
+        "class_type": "UnetLoaderGGUF",
+        "_meta": {
+          "title": "Load GGUF Model"
+        }
+      },
+      "2": {
+        "inputs": {
+          "clip_name": "qwen_3_8b_fp8mixed.safetensors",
+          "type": "flux2"
+        },
+        "class_type": "CLIPLoader",
+        "_meta": {
+          "title": "Load Text Encoder"
+        }
+      },
+      "3": {
+        "inputs": {
+          "vae_name": "flux2-vae.safetensors"
+        },
+        "class_type": "VAELoader",
+        "_meta": {
+          "title": "Load VAE"
+        }
+      },
+      "4": {
         "inputs": {
           "text": "anime cat with massive fluffy fennec ears and a big fluffy tail blonde messy long hair blue eyes wearing a construction outfit placing a fancy black forest cake with candles on top of a dinner table of an old dark Victorian mansion lit by candlelight with a bright window to the foggy forest and very expensive stuff everywhere there are paintings on the walls",
-          "clip": ["30", 1]
+          "clip": ["2", 0]
         },
         "class_type": "CLIPTextEncode",
         "_meta": {
           "title": "CLIP Text Encode (Positive Prompt)"
         }
       },
+      "5": {
+        "inputs": {
+          "text": "",
+          "clip": ["2", 0]
+        },
+        "class_type": "CLIPTextEncode",
+        "_meta": {
+          "title": "CLIP Text Encode (Negative Prompt)"
+        }
+      },
+      "6": {
+        "inputs": {
+          "width": 1024,
+          "height": 1024,
+          "batch_size": 1
+        },
+        "class_type": "EmptyLatentImage",
+        "_meta": {
+          "title": "Empty Latent Image"
+        }
+      },
+      "7": {
+        "inputs": {
+          "seed": 243057879077961,
+          "steps": 4,
+          "cfg": 1,
+          "sampler_name": "euler",
+          "scheduler": "simple",
+          "denoise": 1,
+          "model": ["1", 0],
+          "positive": ["4", 0],
+          "negative": ["5", 0],
+          "latent_image": ["6", 0]
+        },
+        "class_type": "KSampler",
+        "_meta": {
+          "title": "KSampler"
+        }
+      },
       "8": {
         "inputs": {
-          "samples": ["31", 0],
-          "vae": ["30", 2]
+          "samples": ["7", 0],
+          "vae": ["3", 0]
         },
         "class_type": "VAEDecode",
         "_meta": {
@@ -28,83 +89,6 @@
         }
       },
       "9": {
-        "inputs": {
-          "filename_prefix": "ComfyUI",
-          "images": ["8", 0]
-        },
-        "class_type": "SaveImage",
-        "_meta": {
-          "title": "Save Image"
-        }
-      },
-      "27": {
-        "inputs": {
-          "width": 512,
-          "height": 512,
-          "batch_size": 1
-        },
-        "class_type": "EmptySD3LatentImage",
-        "_meta": {
-          "title": "EmptySD3LatentImage"
-        }
-      },
-      "30": {
-        "inputs": {
-          "ckpt_name": "flux1-dev-fp8.safetensors"
-        },
-        "class_type": "CheckpointLoaderSimple",
-        "_meta": {
-          "title": "Load Checkpoint"
-        }
-      },
-      "31": {
-        "inputs": {
-          "seed": 243057879077961,
-          "steps": 10,
-          "cfg": 1,
-          "sampler_name": "euler",
-          "scheduler": "simple",
-          "denoise": 1,
-          "model": ["30", 0],
-          "positive": ["35", 0],
-          "negative": ["33", 0],
-          "latent_image": ["27", 0]
-        },
-        "class_type": "KSampler",
-        "_meta": {
-          "title": "KSampler"
-        }
-      },
-      "33": {
-        "inputs": {
-          "text": "",
-          "clip": ["30", 1]
-        },
-        "class_type": "CLIPTextEncode",
-        "_meta": {
-          "title": "CLIP Text Encode (Negative Prompt)"
-        }
-      },
-      "35": {
-        "inputs": {
-          "guidance": 3.5,
-          "conditioning": ["6", 0]
-        },
-        "class_type": "FluxGuidance",
-        "_meta": {
-          "title": "FluxGuidance"
-        }
-      },
-      "38": {
-        "inputs": {
-          "images": ["8", 0]
-        },
-        "class_type": "PreviewImage",
-        "_meta": {
-          "title": "Preview Image"
-        }
-      },
-      "40": {
         "inputs": {
           "filename_prefix": "ComfyUI",
           "images": ["8", 0]

--- a/test_resources/workflows/workflow_flux2_klein_9b_gguf.json
+++ b/test_resources/workflows/workflow_flux2_klein_9b_gguf.json
@@ -1,0 +1,99 @@
+{
+  "1": {
+    "inputs": {
+      "unet_name": "flux-2-klein-9b-Q5_K_M.gguf"
+    },
+    "class_type": "UnetLoaderGGUF",
+    "_meta": {
+      "title": "Load GGUF Model"
+    }
+  },
+  "2": {
+    "inputs": {
+      "clip_name": "qwen_3_8b_fp8mixed.safetensors",
+      "type": "flux2"
+    },
+    "class_type": "CLIPLoader",
+    "_meta": {
+      "title": "Load Text Encoder"
+    }
+  },
+  "3": {
+    "inputs": {
+      "vae_name": "flux2-vae.safetensors"
+    },
+    "class_type": "VAELoader",
+    "_meta": {
+      "title": "Load VAE"
+    }
+  },
+  "4": {
+    "inputs": {
+      "text": "anime cat with massive fluffy fennec ears and a big fluffy tail blonde messy long hair blue eyes wearing a construction outfit placing a fancy black forest cake with candles on top of a dinner table of an old dark Victorian mansion lit by candlelight with a bright window to the foggy forest and very expensive stuff everywhere there are paintings on the walls",
+      "clip": ["2", 0]
+    },
+    "class_type": "CLIPTextEncode",
+    "_meta": {
+      "title": "CLIP Text Encode (Positive Prompt)"
+    }
+  },
+  "5": {
+    "inputs": {
+      "text": "",
+      "clip": ["2", 0]
+    },
+    "class_type": "CLIPTextEncode",
+    "_meta": {
+      "title": "CLIP Text Encode (Negative Prompt)"
+    }
+  },
+  "6": {
+    "inputs": {
+      "width": 1024,
+      "height": 1024,
+      "batch_size": 1
+    },
+    "class_type": "EmptyLatentImage",
+    "_meta": {
+      "title": "Empty Latent Image"
+    }
+  },
+  "7": {
+    "inputs": {
+      "seed": 243057879077961,
+      "steps": 4,
+      "cfg": 1,
+      "sampler_name": "euler",
+      "scheduler": "simple",
+      "denoise": 1,
+      "model": ["1", 0],
+      "positive": ["4", 0],
+      "negative": ["5", 0],
+      "latent_image": ["6", 0]
+    },
+    "class_type": "KSampler",
+    "_meta": {
+      "title": "KSampler"
+    }
+  },
+  "8": {
+    "inputs": {
+      "samples": ["7", 0],
+      "vae": ["3", 0]
+    },
+    "class_type": "VAEDecode",
+    "_meta": {
+      "title": "VAE Decode"
+    }
+  },
+  "9": {
+    "inputs": {
+      "filename_prefix": "ComfyUI",
+      "images": ["8", 0]
+    },
+    "class_type": "SaveImage",
+    "_meta": {
+      "title": "Save Image"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Switch the default hub deployment model from FLUX.1-dev-fp8 to FLUX.2 klein 9B (Q5_K_M GGUF variant from Unsloth)
- Install ComfyUI-GGUF custom node in the base Docker stage for GGUF model support
- Add `flux2-klein-9b` build target across Dockerfile, docker-bake.hcl, and CI/CD workflows
- Update hub config, documentation, test workflows, and extra_model_paths.yaml

## Breaking Change (6.0.0)

The default hub image ships a different model. Existing workflows using `CheckpointLoaderSimple` with `flux1-dev-fp8.safetensors` won't work on the new default image. Users can use the `flux1-dev-fp8` image tag for backward compatibility.

## Model Details

| File | Size | Directory |
|------|------|-----------|
| `flux-2-klein-9b-Q5_K_M.gguf` | 7.02 GB | `models/unet/` |
| `qwen_3_8b_fp8mixed.safetensors` | 8.66 GB | `models/text_encoders/` |
| `flux2-vae.safetensors` | 336 MB | `models/vae/` |

**Total VRAM:** ~16 GB on 24 GB ADA GPUs (8 GB headroom)

## Test plan

- [ ] Build locally: `docker build --platform linux/amd64 --build-arg MODEL_TYPE=flux2-klein-9b --build-arg HUGGINGFACE_ACCESS_TOKEN=<token> -t test-flux2 .`
- [ ] Verify GGUF model loads correctly with `UnetLoaderGGUF`
- [ ] Verify image generation produces output with `test_input.json`
- [ ] Verify existing `flux1-dev-fp8` target still builds correctly
- [ ] Verify container disk fits within 25 GB

Closes #217