### PR TITLE
feat: forward ComfyUI per-step progress via progress_update

### DIFF
--- a/.changeset/forward-comfyui-progress.md
+++ b/.changeset/forward-comfyui-progress.md
@@ -1,0 +1,30 @@
+---
+"worker-comfyui": minor
+---
+
+feat: forward ComfyUI per-step progress to RunPod via progress_update
+
+The handler now listens for ComfyUI's `progress` (legacy) and
+`progress_state` (current) websocket messages and forwards them through
+`runpod.serverless.progress_update` so `/status` polls observe real
+intermediate progress instead of only the final `IN_PROGRESS` to
+`COMPLETED` jump.
+
+The forwarded payload has a uniform shape regardless of which ComfyUI
+event fired it:
+
+```json
+{
+  "type": "progress",
+  "value": 12,
+  "max": 25,
+  "percent": 48.0,
+  "node": "3"
+}
+```
+
+For `progress_state` messages (which report a snapshot of every node)
+`value` and `max` are summed across all nodes belonging to the current
+prompt so multi-sampler graphs still produce a single monotonic
+percentage. `progress_update` failures are caught and logged so progress
+reporting never aborts the job itself.

--- a/handler.py
+++ b/handler.py
@@ -569,6 +569,65 @@ def get_image_data(filename, subfolder, image_type):
         return None
 
 
+def _build_progress_payload(message, prompt_id):
+    """Translate a ComfyUI 'progress' or 'progress_state' websocket message
+    into {type, value, max, percent, node}; return None to skip."""
+    if not isinstance(message, dict):
+        return None
+    msg_type = message.get("type")
+    data = message.get("data") or {}
+
+    if msg_type == "progress":
+        if data.get("prompt_id") not in (None, prompt_id):
+            return None
+        try:
+            value = float(data.get("value", 0))
+            max_value = float(data.get("max", 0))
+        except (TypeError, ValueError):
+            return None
+        if max_value <= 0:
+            return None
+        return {
+            "type": "progress",
+            "value": int(value),
+            "max": int(max_value),
+            "percent": round((value / max_value) * 100.0, 2),
+            "node": data.get("node"),
+        }
+
+    if msg_type == "progress_state":
+        if data.get("prompt_id") not in (None, prompt_id):
+            return None
+        nodes = data.get("nodes") or {}
+        if not isinstance(nodes, dict) or not nodes:
+            return None
+        total_value = 0.0
+        total_max = 0.0
+        for node in nodes.values():
+            if not isinstance(node, dict):
+                continue
+            try:
+                node_max = float(node.get("max", 0))
+                node_value = float(node.get("value", 0))
+            except (TypeError, ValueError):
+                continue
+            if node_max <= 0:
+                continue
+            total_value += node_value
+            total_max += node_max
+        if total_max <= 0:
+            return None
+        return {
+            "type": "progress",
+            "value": int(total_value),
+            "max": int(total_max),
+            "percent": round((total_value / total_max) * 100.0, 2),
+            "node": None,
+        }
+
+    return None
+
+
 def handler(job):
     """
     Handles a job using ComfyUI via websockets for status and image retrieval.
@@ -689,6 +748,15 @@ def handler(job):
                             )
                             errors.append(f"Workflow execution error: {error_details}")
                             break
+                    elif message.get("type") in ("progress", "progress_state"):
+                        payload = _build_progress_payload(message, prompt_id)
+                        if payload is not None:
+                            try:
+                                runpod.serverless.progress_update(job, payload)
+                            except Exception as progress_err:
+                                print(
+                                    f"worker-comfyui - progress_update failed (non-fatal): {progress_err}"
+                                )
                 else:
                     continue
             except websocket.WebSocketTimeoutException:


### PR DESCRIPTION
The handler opens a websocket to ComfyUI for completion detection (added in #118) but only branches on `status`, `executing`, and `execution_error`. ComfyUI also emits two progress shapes that currently fall through:

- `progress` (legacy, per sampler step)
- `progress_state` (current, snapshot of every node)

This forwards both via `runpod.serverless.progress_update(job, payload)` so `/status` polls see real intermediate progress under `output` while status is `IN_PROGRESS`, instead of jumping straight to `COMPLETED`.

The forwarded payload is normalised to one shape so clients don't branch:

```json
{"type": "progress", "value": 12, "max": 25, "percent": 48.0, "node": "3"}
```

For `progress_state`, value/max are summed across nodes belonging to the current `prompt_id` so multi-sampler graphs produce a single monotonic percentage. `progress_update` exceptions are caught and logged so progress reporting can never fail the job. Changeset added as `minor`.

Closes #36