### PR TITLE
fix(hub): broaden allowedCudaVersions and lower default log level

### DIFF
--- a/.changeset/fix-hub-cuda-versions-and-log-level.md
+++ b/.changeset/fix-hub-cuda-versions-and-log-level.md
@@ -1,0 +1,8 @@
+---
+"worker-comfyui": patch
+---
+
+fix: broaden `allowedCudaVersions` in hub config and lower default log level
+
+- Expand `allowedCudaVersions` in `.runpod/hub.json` and `.runpod/tests_.json` to include `12.8`, `12.9`, and `13.0`. The previous `["12.7", "12.6"]` allow-list excluded the majority of modern Runpod hosts (which run CUDA 12.8+), causing hub deployments to land on incompatible hosts and crash-loop with `nvidia-container-cli: requirement error: unsatisfied condition: cuda>=12.6`.
+- Change default `COMFY_LOG_LEVEL` from `DEBUG` to `INFO`. With `DEBUG`, more than 75% of worker log lines were low-level comfy internals (`apply_rope1`, `Backend eager selected`, `aimdo: src/...:DEBUG:`, `Popen([...])`), drowning out the actual handler output. Users who want verbose logs can still set `COMFY_LOG_LEVEL=DEBUG` explicitly.

--- a/.runpod/hub.json
+++ b/.runpod/hub.json
@@ -9,7 +9,7 @@
     "containerDiskInGb": 20,
     "gpuIds": "ADA_24",
     "gpuCount": 1,
-    "allowedCudaVersions": ["12.7", "12.6"],
+    "allowedCudaVersions": ["13.0", "12.9", "12.8", "12.7", "12.6"],
     "env": [
       {
         "key": "COMFY_ORG_API_KEY",
@@ -67,7 +67,7 @@
           "name": "ComfyUI Log Level",
           "type": "string",
           "description": "Log level for ComfyUI (DEBUG, INFO, WARNING, ERROR, CRITICAL)",
-          "default": "DEBUG",
+          "default": "INFO",
           "advanced": true
         }
       },

--- a/.runpod/tests_.json
+++ b/.runpod/tests_.json
@@ -131,6 +131,6 @@
         "value": "false"
       }
     ],
-    "allowedCudaVersions": ["12.7", "12.6"]
+    "allowedCudaVersions": ["13.0", "12.9", "12.8", "12.7", "12.6"]
   }
 }


### PR DESCRIPTION
## Summary

Two related hub-config fixes that came out of a live validation of #186 (PR #197) on 5.8.5:

1. **`allowedCudaVersions`** in `.runpod/hub.json` and `.runpod/tests_.json` was locked to `[\"12.7\", \"12.6\"]`. That's an allow-list, not a minimum — so every modern Runpod host running CUDA 12.8/12.9/13.0 drivers (which can backwards-compat run a 12.6 container fine) was excluded from scheduling. Result: hub deployments landed on the small pool of legacy hosts and crash-looped with:

   ```
   nvidia-container-cli: requirement error: unsatisfied condition: cuda>=12.6,
   please update your driver to a newer version, or use an earlier cuda container
   ```

   The 5.8.5 worker on a 4090 sat in this loop until I patched the live endpoint via REST API to include 12.8/12.9/13.0 — then a fresh worker spawned on a compatible host and the FLUX.1-dev-fp8 cold-start test job completed in 23.1s execution time (validating PR #197).

2. **`COMFY_LOG_LEVEL`** default was `DEBUG`. In a real cold-start log (1330 lines), only ~25 lines were actual worker-comfyui output — the other ~1300 were low-level comfy internals: hundreds of `Backend eager selected for apply_rope1`, `aimdo: src/control.c:34:DEBUG: --- VRAM Stats ---`, `Popen([...])` subprocess noise. Switching the default to `INFO` keeps the handler output readable while leaving `DEBUG` available for users who explicitly opt in.

## Related issues

- Same symptom likely contributes to **#94** (`Found no NVIDIA driver`) and the unresolvable-CUDA failure mode discussed in **#186**.

## Test plan

- [x] Reproduced the OCI failure on a fresh hub deploy of 5.8.5
- [x] After expanding `allowedCudaVersions` via REST on the live endpoint, fresh worker spawned and completed a FLUX.1-dev-fp8 job (23.1s exec, 1 image returned)
- [ ] Re-deploy from hub after merge + release and verify cold start lands on a 12.8+ host without intervention
- [ ] Confirm logs at the new INFO default no longer contain the `apply_rope1` / `aimdo:` spam