### PR TITLE
ci: build base image on every pull request

### DIFF
--- a/.changeset/ci-build-on-pull-request.md
+++ b/.changeset/ci-build-on-pull-request.md
@@ -1,0 +1,7 @@
+---
+"worker-comfyui": patch
+---
+
+ci: build base image on every pull request so PR changes are testable before merge
+
+Previously the `Development` workflow only ran on manual `workflow_dispatch`, and `release.yml` only built images after a `chore: version packages` commit landed on `main`. That meant fixes couldn't be deployed and tested on a real Runpod endpoint until they were already merged. With this change, opening or pushing to a PR builds and pushes a `base` image tagged with the branch slug (e.g. `:fix-pin-boto3`), so reviewers can deploy that exact image to a serverless endpoint and verify behavior before approval.

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -2,9 +2,12 @@ name: Development
 
 on:
   workflow_dispatch:
-#  push:
-#    branches-ignore:
-#      - main
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    paths-ignore:
+      - "**.md"
+      - "docs/**"
+      - ".changeset/**"
 
 jobs:
   dev:
@@ -42,7 +45,11 @@ jobs:
           echo "DOCKERHUB_REPO=${{ vars.DOCKERHUB_REPO }}" >> $GITHUB_ENV
           echo "DOCKERHUB_IMG=${{ vars.DOCKERHUB_IMG }}" >> $GITHUB_ENV
           echo "HUGGINGFACE_ACCESS_TOKEN=${{ secrets.HUGGINGFACE_ACCESS_TOKEN }}" >> $GITHUB_ENV
-          echo "RELEASE_VERSION=${GITHUB_REF##refs/heads/}" | sed 's/\//-/g' >> $GITHUB_ENV
+          # On pull_request: GITHUB_HEAD_REF is the source branch (e.g. fix/foo).
+          # On workflow_dispatch / push: fall back to the ref's branch name.
+          BRANCH="${GITHUB_HEAD_REF:-${GITHUB_REF##refs/heads/}}"
+          BRANCH_SLUG=$(echo "$BRANCH" | sed 's/[^a-zA-Z0-9._-]/-/g')
+          echo "RELEASE_VERSION=${BRANCH_SLUG}" >> $GITHUB_ENV
 
       - name: Build and push the base image to Docker Hub
         uses: docker/bake-action@v2


### PR DESCRIPTION
## Summary

Today the \`Development\` workflow only runs on manual \`workflow_dispatch\`, and the \`release\` workflow only builds images after a \`chore: version packages\` commit lands on \`main\`. So PR changes can't be deployed to a real serverless endpoint until they're already merged. That makes it impossible to validate behavior before approval — we're flying blind.

This PR makes \`Development\` build the \`base\` image on every PR push (opened / synchronize / reopened / ready_for_review), tagged with the branch slug. So opening this very PR should produce \`runpod/worker-comfyui:ci-build-on-pull-request-base\` (or whatever the configured DOCKERHUB_REPO/IMG resolves to). Then deploying a serverless endpoint with that image lets us test the PR.

## Changes

- \`.github/workflows/dev.yml\`
  - Add \`pull_request\` trigger with \`paths-ignore\` for docs/changeset-only PRs
  - Compute \`RELEASE_VERSION\` from \`GITHUB_HEAD_REF\` first (PR source branch), falling back to \`GITHUB_REF\` for push/dispatch
  - Slug branch name into Docker-safe tag (replace anything not \`[a-zA-Z0-9._-]\` with \`-\`)

## Why \`paths-ignore\`

Builds are heavy (~20-30 min on Blacksmith). Skip the build for PRs that only touch markdown, \`docs/\`, or \`.changeset/\` files. Behavior-affecting PRs (anything in \`src/\`, \`handler.py\`, \`Dockerfile\`, workflows, \`.runpod/\`) still trigger a build.

## Risks

- Every PR now consumes Blacksmith runner minutes for a \`base\` build. If that becomes too expensive, we can switch to label-gated builds (only build if a \`build\` label is present).
- Docker Hub will accumulate one tag per branch. \`docker-prune.yml\` already exists to clean these up periodically — recommend extending it if needed.

## Test plan

- [x] Push to this branch and confirm \`Development\` workflow triggers
- [ ] Confirm the produced image tag matches the branch slug
- [ ] Deploy a serverless endpoint from the new image and submit a real job to confirm the worker still functions normally (no behavior change, just CI plumbing)