### PR TITLE
fix: pin boto3<1.40 to keep non-AWS S3 uploads working

### DIFF
--- a/.changeset/pin-boto3-for-non-aws-s3.md
+++ b/.changeset/pin-boto3-for-non-aws-s3.md
@@ -1,0 +1,7 @@
+---
+"worker-comfyui": patch
+---
+
+fix: pin `boto3<1.40` so S3 uploads to non-AWS providers (Cloudflare R2, Google Cloud Storage) keep working
+
+boto3 1.40 ships a botocore release that enforces stricter AWS-only auth flows; uploads to S3-compatible endpoints like GCS and R2 began failing with `SignatureDoesNotMatch`. The fix is a version pin until upstream `runpod` and `aioboto3` stabilize on the new botocore. Reporter on #156 isolated this exactly: `boto3==1.35.40` works, `1.40.1` breaks.

--- a/Dockerfile
+++ b/Dockerfile
@@ -71,8 +71,11 @@ ADD src/extra_model_paths.yaml ./
 # Go back to the root
 WORKDIR /
 
-# Install Python runtime dependencies for the handler
-RUN uv pip install runpod requests websocket-client
+# Install Python runtime dependencies for the handler.
+# Pin boto3 < 1.40 to keep S3 uploads working against non-AWS S3 endpoints
+# (Cloudflare R2, Google Cloud Storage). boto3 1.40+ ships a botocore that
+# enforces stricter AWS-only auth flows; see issue #156.
+RUN uv pip install runpod requests websocket-client 'boto3<1.40'
 
 # Add application code and scripts
 ADD src/start.sh src/network_volume.py handler.py test_input.json ./


### PR DESCRIPTION
## Summary

Closes #156.

boto3 1.40 ships a botocore release that enforces stricter AWS-only auth flows. Uploads to S3-compatible endpoints (Cloudflare R2, Google Cloud Storage) began failing with \`SignatureDoesNotMatch\`. The reporter on #156 narrowed it down precisely:

- \`boto3==1.35.40\` → works against GCS
- \`boto3==1.40.1\` → fails

Related upstream: https://github.com/terricain/aioboto3/issues/358

## Fix

Pin \`boto3<1.40\` in the handler runtime install line in \`Dockerfile\` (boto3 isn't a direct dep — it comes transitively through \`runpod\`, so we add an explicit constraint).

## Test plan

- [ ] Build the PR image via the \`Development\` workflow (depends on #223 being merged so this happens automatically)
- [ ] Deploy a serverless endpoint with the PR image
- [ ] Set \`BUCKET_ENDPOINT_URL\` to a GCS or R2 bucket and submit a workflow that produces an image
- [ ] Confirm the upload succeeds (response includes \`type: s3_url\`, no \`SignatureDoesNotMatch\` in logs)