### PR TITLE
Update allowedCudaVersions to 13.0 in hub.json

### DIFF
--- a/.runpod/hub.json
+++ b/.runpod/hub.json
@@ -9,7 +9,7 @@
     "containerDiskInGb": 20,
     "gpuIds": "ADA_24",
     "gpuCount": 1,
-    "allowedCudaVersions": ["12.7", "12.6"],
+    "allowedCudaVersions": ["13.0"],
     "env": [
       {
         "key": "COMFY_ORG_API_KEY",


### PR DESCRIPTION
## Summary
- Set `allowedCudaVersions` to `["13.0"]` in `.runpod/hub.json` (was `["12.7", "12.6"]`)

🤖 Generated with [Claude Code](https://claude.ai/code)