### PR TITLE
Pin ComfyUI to 0.29.0, build with CUDA 12.8, expand allowed CUDA versions to 12.8–13.3

### DIFF
--- a/.changeset/pin-comfyui-cuda-12-8.md
+++ b/.changeset/pin-comfyui-cuda-12-8.md
@@ -2,4 +2,4 @@
 "worker-comfyui": minor
 ---
 
-Pin ComfyUI to 0.29.0, build on CUDA 12.8, and pin the runtime PyTorch to 2.11.0+cu128 so the image runs on every host allowed by the Hub config. `allowedCudaVersions` in `.runpod/hub.json` moves from 12.6/12.7 to 12.8–13.3 (driver >= 570). Existing Hub endpoints keep the old release and its near-exhausted 12.6/12.7 host pool — update your endpoint to this release to pick up the new host range.
+Pin ComfyUI to 0.29.0, build on CUDA 12.8, and pin the runtime PyTorch to 2.11.0+cu128 so the image runs on every host allowed by the Hub config. `allowedCudaVersions` in `.runpod/hub.json` moves from 12.6/12.7 to 12.8–13.0 (driver >= 570). Existing Hub endpoints keep the old release and its near-exhausted 12.6/12.7 host pool — update your endpoint to this release to pick up the new host range.

--- a/.changeset/pin-comfyui-cuda-12-8.md
+++ b/.changeset/pin-comfyui-cuda-12-8.md
@@ -1,0 +1,5 @@
+---
+"worker-comfyui": minor
+---
+
+Pin ComfyUI to 0.29.0, build on CUDA 12.8, and pin the runtime PyTorch to 2.11.0+cu128 so the image runs on every host allowed by the Hub config. `allowedCudaVersions` in `.runpod/hub.json` moves from 12.6/12.7 to 12.8–13.3 (driver >= 570). Existing Hub endpoints keep the old release and its near-exhausted 12.6/12.7 host pool — update your endpoint to this release to pick up the new host range.

--- a/.runpod/hub.json
+++ b/.runpod/hub.json
@@ -9,7 +9,7 @@
     "containerDiskInGb": 20,
     "gpuIds": "ADA_24",
     "gpuCount": 1,
-    "allowedCudaVersions": ["12.8", "12.9", "13.0", "13.1", "13.2", "13.3"],
+    "allowedCudaVersions": ["12.8", "12.9", "13.0"],
     "env": [
       {
         "key": "COMFY_ORG_API_KEY",

--- a/.runpod/hub.json
+++ b/.runpod/hub.json
@@ -9,7 +9,7 @@
     "containerDiskInGb": 20,
     "gpuIds": "ADA_24",
     "gpuCount": 1,
-    "allowedCudaVersions": ["12.7", "12.6"],
+    "allowedCudaVersions": ["12.8", "12.9", "13.0", "13.1", "13.2", "13.3"],
     "env": [
       {
         "key": "COMFY_ORG_API_KEY",

--- a/.runpod/tests_.json
+++ b/.runpod/tests_.json
@@ -131,6 +131,6 @@
         "value": "false"
       }
     ],
-    "allowedCudaVersions": ["12.7", "12.6"]
+    "allowedCudaVersions": ["12.8", "12.9", "13.0", "13.1", "13.2", "13.3"]
   }
 }

--- a/.runpod/tests_.json
+++ b/.runpod/tests_.json
@@ -131,6 +131,6 @@
         "value": "false"
       }
     ],
-    "allowedCudaVersions": ["12.8", "12.9", "13.0", "13.1", "13.2", "13.3"]
+    "allowedCudaVersions": ["12.8", "12.9", "13.0"]
   }
 }

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
 # Build argument for base image selection
-ARG BASE_IMAGE=nvidia/cuda:12.6.3-cudnn-runtime-ubuntu24.04
+ARG BASE_IMAGE=nvidia/cuda:12.8.1-cudnn-runtime-ubuntu24.04
 
 # Stage 1: Base image with common dependencies
 FROM ${BASE_IMAGE} AS base
 
 # Build arguments for this stage with sensible defaults for standalone builds
-ARG COMFYUI_VERSION=latest
-ARG CUDA_VERSION_FOR_COMFY
+ARG COMFYUI_VERSION=0.29.0
+ARG CUDA_VERSION_FOR_COMFY=12.8
 ARG ENABLE_PYTORCH_UPGRADE=false
 ARG PYTORCH_INDEX_URL
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,7 +48,9 @@ RUN wget -qO- https://astral.sh/uv/install.sh | sh \
 ENV PATH="/opt/venv/bin:${PATH}"
 
 # Install comfy-cli + dependencies needed by it to install ComfyUI
-RUN uv pip install comfy-cli pip setuptools wheel
+# comfy-cli is pinned: its install/torch-index behavior decides what lands in
+# the workspace venv, so an unpinned version makes builds non-reproducible.
+RUN uv pip install comfy-cli==1.13.0 pip setuptools wheel
 
 # Install ComfyUI
 RUN if [ -n "${CUDA_VERSION_FOR_COMFY}" ]; then \
@@ -76,7 +78,17 @@ RUN if [ "$ENABLE_PYTORCH_UPGRADE" = "true" ]; then \
 # breaking API changes also crash ComfyUI at startup. Pinning them in the same
 # RUN downgrades within one layer, so the unwanted versions aren't left behind
 # bloating the image.
-RUN uv pip install -r /comfyui/requirements.txt \
+#
+# torch is installed FIRST, pinned to +cu128 builds: ComfyUI's requirements.txt
+# declares a bare `torch`, and default PyPI serves CUDA 13 builds (torch's PyPI
+# wheels depend on nvidia-*-cu13 since 2.11) that require driver >= 580. Hosts
+# allowed in .runpod/hub.json advertise CUDA 12.8/12.9 (driver 570/575), where
+# a cu13 torch fails CUDA init at startup. cu128 builds run on driver >= 570,
+# i.e. every allowed host. Installing torch first satisfies the bare `torch`
+# requirement so the PyPI pass doesn't touch it.
+RUN uv pip install torch==2.11.0 torchvision==0.26.0 torchaudio==2.11.0 \
+      --index-url https://download.pytorch.org/whl/cu128 \
+    && uv pip install -r /comfyui/requirements.txt \
     && for r in /comfyui/custom_nodes/*/requirements.txt; do \
          [ -f "$r" ] && uv pip install -r "$r" || true; \
        done \

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -11,16 +11,16 @@ variable "RELEASE_VERSION" {
 }
 
 variable "COMFYUI_VERSION" {
-  default = "latest"
+  default = "0.29.0"
 }
 
-# Global defaults for standard CUDA 12.6.3 images
+# Global defaults for standard CUDA 12.8.1 images
 variable "BASE_IMAGE" {
-  default = "nvidia/cuda:12.6.3-cudnn-runtime-ubuntu24.04"
+  default = "nvidia/cuda:12.8.1-cudnn-runtime-ubuntu24.04"
 }
 
 variable "CUDA_VERSION_FOR_COMFY" {
-  default = "12.6"
+  default = "12.8"
 }
 
 variable "ENABLE_PYTORCH_UPGRADE" {


### PR DESCRIPTION
## What

- **Pin ComfyUI to `0.29.0`** (latest stable release, 2026-07-29) instead of `latest`, so builds are reproducible and don't silently change between deploys. comfy-cli is also pinned (`1.13.0`) for the same reason.
- **Build with CUDA 12.8**: default base image moves from `nvidia/cuda:12.6.3-cudnn-runtime-ubuntu24.04` to `nvidia/cuda:12.8.1-cudnn-runtime-ubuntu24.04` (Dockerfile defaults + `docker-bake.hcl` globals).
- **Pin the RUNTIME PyTorch to `2.11.0+cu128`**: the venv that actually runs ComfyUI (`/opt/venv`) previously got its torch from default PyPI via the requirements mirror step — and PyPI torch ≥ 2.11 ships CUDA 13 builds (`nvidia-*-cu13` deps) that require driver ≥ 580. That's incompatible with hosts advertising CUDA 12.8/12.9 (driver 570/575) and is likely the source of the current torch-related worker failures. Installing `torch==2.11.0+cu128` before the mirror step satisfies ComfyUI's bare `torch` requirement, so the runtime torch is now a known cu128 build that runs on driver ≥ 570.
- **`.runpod/hub.json`**: `allowedCudaVersions` updated from `["12.7", "12.6"]` to `["12.8", "12.9", "13.0"]`. The disabled `.runpod/tests_.json` is synced to the same list.
- **Changeset added** (`minor`) so the change ships with the next release cut.

## Validated on real hosts (2026-07-30)

This exact build (base target, PR Dockerfile defaults) was pushed to a test registry and run as a serverless endpoint pinned to each CUDA version, one job per host type:

| Host CUDA | GPU | Result |
|---|---|---|
| 12.8 | RTX 4090 | ✅ COMPLETED — worker healthy (GPU pre-flight passed), workflow executed, image returned (exec 3.0s) |
| 12.9 | RTX 5090 / H200 | ⚠️ Could not schedule — no 12.9 host became available during the test window (capacity, not compatibility; cu128 requires driver ≥ 570, which 12.9 hosts satisfy by definition). Kept in the allowlist — harmless, and correct when 12.9 hosts appear. |
| 13.0 | RTX 4090 | ✅ COMPLETED — worker healthy, workflow executed, image returned (exec 3.1s) |

Additional validation notes:
- The allowlist ceiling of **13.0 matches Runpod's API schema exactly**: the platform's CUDA version enum currently ends at "13.0" — values above it don't exist yet, so this list covers every currently-valid version ≥ 12.8. When the platform adds 13.1+, extend the list (or switch to `minCudaVersion` if hub.json gains support for it — floor-only semantics avoid this ceiling maintenance entirely).
- The old `12.6/12.7` list is nearly dead capacity-wise (zero community-cloud 4090 stock, Low secure on 12.7 only); current ADA_24 stock is concentrated on 12.8 and 13.0 hosts, so this change is a strict capacity improvement and unlocks community cloud.
- CUDA 12.8 + cu128 torch also unlocks Blackwell (sm_120 / RTX 5090) support.

## Known limitations / follow-ups

- `comfy --install`'s workspace venv (`/comfyui/.venv`) still receives its own unused torch (~5–7 GB installed). Removing it is a follow-up image-size win, left out here to keep this change low-risk.
- The `base-cuda12-8-1` bake target now produces nearly the same image as `base` (both end with a cu128 runtime torch). Left untouched since `release.yml`/`manual-build-all.yml` reference it by name; consolidating is a follow-up.
- Existing Hub endpoints keep the old release and its exhausted 12.6/12.7 host pool — release notes should tell users to update their endpoint.

## Verification (build-time)

- `torch==2.11.0+cu128` / `torchvision==0.26.0+cu128` / `torchaudio==2.11.0+cu128` cp312 manylinux wheels confirmed present on the cu128 index (it caps at 2.11.0 — newer torch is cu129/cu13x only).
- ComfyUI 0.29.0's requirements verified compatible with the existing `transformers>=4.50.3,<5` / `huggingface-hub<1.0` pins (DR-1170); `--quick-test-for-ci --cpu` flags still exist in 0.29.0, so the build-time smoke test keeps catching startup-breaking deps.
- Pinning `--version 0.29.0` resolves the tag by string construction in comfy-cli — no GitHub API call, removing the rate-limit risk that `latest` resolution carries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)