### PR TITLE
fix: point console links at final URLs, correct Runpod brand casing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
 # worker-comfyui
 
-> [ComfyUI](https://github.com/comfyanonymous/ComfyUI) as a serverless API on [RunPod](https://www.runpod.io/)
+> [ComfyUI](https://github.com/comfyanonymous/ComfyUI) as a serverless API on [Runpod](https://www.runpod.io/)
 
 <p align="center">
   <img src="assets/worker_sitting_in_comfy_chair.jpg" title="Worker sitting in comfy chair" />
 </p>
 
-[![RunPod](https://api.runpod.io/badge/runpod-workers/worker-comfyui)](https://console.runpod.io/hub/runpod-workers/worker-comfyui)
+[![Runpod](https://api.runpod.io/badge/runpod-workers/worker-comfyui)](https://console.runpod.io/hub/runpod-workers/worker-comfyui)
 
 ---
 
-This project allows you to run ComfyUI workflows as a serverless API endpoint on the RunPod platform. Submit workflows via API calls and receive generated images as base64 strings or S3 URLs.
+This project allows you to run ComfyUI workflows as a serverless API endpoint on the Runpod platform. Submit workflows via API calls and receive generated images as base64 strings or S3 URLs.
 
 ## Table of Contents
 
@@ -26,7 +26,7 @@ This project allows you to run ComfyUI workflows as a serverless API endpoint on
 ## Quickstart
 
 1.  🐳 Choose one of the [available Docker images](#available-docker-images) for your serverless endpoint (e.g., `runpod/worker-comfyui:<version>-sd3`).
-2.  📄 Follow the [Deployment Guide](docs/deployment.md) to set up your RunPod template and endpoint.
+2.  📄 Follow the [Deployment Guide](docs/deployment.md) to set up your Runpod template and endpoint.
 3.  ⚙️ Optionally configure the worker (e.g., for S3 upload) using environment variables - see the full [Configuration Guide](docs/configuration.md).
 4.  🧪 Pick an example workflow from [`test_resources/workflows/`](./test_resources/workflows/) or [get your own](#getting-the-workflow-json).
 5.  🚀 Follow the [Usage](#usage) steps below to interact with your deployed endpoint.
@@ -45,7 +45,7 @@ Replace `<version>` with the current release tag, check the [releases page](http
 
 ## API Specification
 
-The worker exposes standard RunPod serverless endpoints (`/run`, `/runsync`, `/health`). By default, images are returned as base64 strings. You can configure the worker to upload images to an S3 bucket instead by setting specific environment variables (see [Configuration Guide](docs/configuration.md)).
+The worker exposes standard Runpod serverless endpoints (`/run`, `/runsync`, `/health`). By default, images are returned as base64 strings. You can configure the worker to upload images to an S3 bucket instead by setting specific environment variables (see [Configuration Guide](docs/configuration.md)).
 
 Use the `/runsync` endpoint for synchronous requests that wait for the job to complete and return the result directly. Use the `/run` endpoint for asynchronous requests that return immediately with a job ID; you'll need to poll the `/status` endpoint separately to get the result.
 
@@ -96,7 +96,7 @@ Each object within the `input.images` array must contain:
 
 > [!NOTE]
 >
-> **Size Limits:** RunPod endpoints have request size limits (e.g., 10MB for `/run`, 20MB for `/runsync`). Large base64 input images can exceed these limits. See [RunPod Docs](https://docs.runpod.io/docs/serverless-endpoint-urls).
+> **Size Limits:** Runpod endpoints have request size limits (e.g., 10MB for `/run`, 20MB for `/runsync`). Large base64 input images can exceed these limits. See [Runpod Docs](https://docs.runpod.io/docs/serverless-endpoint-urls).
 
 ### Output
 
@@ -150,9 +150,9 @@ Each object in the `output.images` array has the following structure:
 
 ## Usage
 
-To interact with your deployed RunPod endpoint:
+To interact with your deployed Runpod endpoint:
 
-1.  **Get API Key:** Generate a key in RunPod [User Settings](https://console.runpod.io/serverless/user/settings) (`API Keys` section).
+1.  **Get API Key:** Generate a key in Runpod [User Settings](https://console.runpod.io/serverless/user/settings) (`API Keys` section).
 2.  **Get Endpoint ID:** Find your endpoint ID on the [Serverless Endpoints](https://console.runpod.io/serverless) page or on the `Overview` page of your endpoint.
 
 ### Generate Image (Sync Example)
@@ -181,11 +181,11 @@ To get the correct `workflow` JSON for the API:
 
 ## SSH Access
 
-To enable SSH access to the worker, set the `PUBLIC_KEY` environment variable to your SSH public key. The worker will start an SSH server automatically. Make sure to expose **port 22** in your RunPod template so you can connect.
+To enable SSH access to the worker, set the `PUBLIC_KEY` environment variable to your SSH public key. The worker will start an SSH server automatically. Make sure to expose **port 22** in your Runpod template so you can connect.
 
 ## Further Documentation
 
-- **[Deployment Guide](docs/deployment.md):** Detailed steps for deploying on RunPod.
+- **[Deployment Guide](docs/deployment.md):** Detailed steps for deploying on Runpod.
 - **[Configuration Guide](docs/configuration.md):** Full list of environment variables (including S3 setup).
 - **[Customization Guide](docs/customization.md):** Adding custom models and nodes (Network Volumes, Docker builds).
 - **[Development Guide](docs/development.md):** Setting up a local environment for development & testing

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
   <img src="assets/worker_sitting_in_comfy_chair.jpg" title="Worker sitting in comfy chair" />
 </p>
 
-[![RunPod](https://api.runpod.io/badge/runpod-workers/worker-comfyui)](https://www.runpod.io/console/hub/runpod-workers/worker-comfyui)
+[![RunPod](https://api.runpod.io/badge/runpod-workers/worker-comfyui)](https://console.runpod.io/hub/runpod-workers/worker-comfyui)
 
 ---
 
@@ -152,8 +152,8 @@ Each object in the `output.images` array has the following structure:
 
 To interact with your deployed RunPod endpoint:
 
-1.  **Get API Key:** Generate a key in RunPod [User Settings](https://www.runpod.io/console/serverless/user/settings) (`API Keys` section).
-2.  **Get Endpoint ID:** Find your endpoint ID on the [Serverless Endpoints](https://www.runpod.io/console/serverless/user/endpoints) page or on the `Overview` page of your endpoint.
+1.  **Get API Key:** Generate a key in RunPod [User Settings](https://console.runpod.io/serverless/user/settings) (`API Keys` section).
+2.  **Get Endpoint ID:** Find your endpoint ID on the [Serverless Endpoints](https://console.runpod.io/serverless) page or on the `Overview` page of your endpoint.
 
 ### Generate Image (Sync Example)
 


### PR DESCRIPTION
Two small README fixes, in separate commits so either can be dropped.

## 1. Console links point at legacy paths

Three links use `www.runpod.io/console/*`, which 301s to the console subdomain. Readers take an extra hop, and link graphs record the citation as indirect rather than direct. Surfaced while triaging an Ahrefs lost-backlink report, where these showed up as `lostredirect`.

Verified each destination returns 200 before changing it:

| Was | Now |
|---|---|
| `www.runpod.io/console/serverless/user/settings` | `console.runpod.io/serverless/user/settings` |
| `www.runpod.io/console/serverless/user/endpoints` | `console.runpod.io/serverless` |
| `www.runpod.io/console/hub/runpod-workers/worker-comfyui` | `console.runpod.io/hub/runpod-workers/worker-comfyui` |

Worth flagging the middle one: the endpoints path resolves to `/serverless`, not to a like-named path on the console subdomain. A mechanical prefix swap would have produced `console.runpod.io/serverless/user/endpoints`, which is a 404. Nothing currently links there, but it is an easy trap if anyone repeats this by hand elsewhere.

No user-facing breakage today, every existing link works. This is hop removal and citation hygiene.

## 2. Brand casing (separate commit)

The brand is Runpod, not RunPod. The README had 11 of the old casing and none of the current one. Same correction already merged in the docs repo.

Prose only. Every URL in the file already uses lowercase `runpod`, and the script aborts if the string appears inside a link, so no paths or identifiers moved.

## Note on Docker Hub

`release.yml`, `manual-push-dockerhub.yml`, and `manual-build-all.yml` all sync this README to the Docker Hub description, so merging propagates there on the next release without any separate step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
